### PR TITLE
fix: prevent fd leak in TraversalType2 implementation #206

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+libappimage (1.0.4-5-3deepin1) unstable; urgency=medium
+
+  * prevent fd leak in TraversalType2 implementation
+
+ -- Zhang Sheng <zhangsheng@uniontech.com>  Wed, 05 Nov 2025 13:44:42 +0800
+
 libappimage (1.0.4-5-3) unstable; urgency=medium
 
   * Team upload.

--- a/debian/patches/Fix-fd-leak.patch
+++ b/debian/patches/Fix-fd-leak.patch
@@ -1,0 +1,33 @@
+Index: deepin_libappimage/src/libappimage/core/impl/TraversalType2.cpp
+===================================================================
+--- deepin_libappimage.orig/src/libappimage/core/impl/TraversalType2.cpp
++++ deepin_libappimage/src/libappimage/core/impl/TraversalType2.cpp
+@@ -8,6 +8,7 @@
+  extern "C" {
+ #include <squashfuse.h>
+ #include <squashfs_fs.h>
++#include <squashfuse/util.h>
+ }
+ 
+ // system
+@@ -52,7 +53,9 @@ public:
+         rootInodeId = sqfs_inode_root(&fs);
+         err = sqfs_traverse_open(&trv, &fs, rootInodeId);
+         if (err != SQFS_OK) {
++            sqfs_fd_t fd = fs.fd;
+             sqfs_destroy(&fs);
++            sqfs_fd_close(fd);
+             throw IOError("sqfs_traverse_open error");
+         }
+     }
+@@ -60,7 +63,10 @@ public:
+     virtual ~Priv() {
+         sqfs_traverse_close(&trv);
+ 
++        sqfs_fd_t fd = fs.fd;
++
+         sqfs_destroy(&fs);
++        sqfs_fd_close(fd);
+     }
+ 
+     bool isCompleted() const {

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,3 +1,4 @@
 upstream_Fix-typos-Unsuported-Unsupported-180.patch
 upstream_Fix-build-with-gcc-13.1.1.patch
 enable_debianabimanager.diff
+Fix-fd-leak.patch


### PR DESCRIPTION
sqfs_destroy only releases memory resources and does not close file descriptors.

Log: